### PR TITLE
Fix exclude config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This module logs requests for following data to a database table.
 * cookies
 * agent
 
-It is possible to exclude certain private fields through configuration (contributed by [@AgelxNash](https://github.com/AgelxNash)) 
+It is possible to exclude certain private fields through configuration (contributed by [@AgelxNash](https://github.com/AgelxNash)).
+**By default, all session cookies and xsrf tokens are excluded from being logged.**
 
 Installation
 ------------

--- a/src/LogRequest.php
+++ b/src/LogRequest.php
@@ -111,7 +111,7 @@ class LogRequest
      */
     protected function getExceptGet() : array
     {
-        return property_exists($this, 'exceptGet') ? $this->exceptGet : config('request-logger.except.get');
+        return property_exists($this, 'exceptGet') ? $this->exceptGet : config('request-logger.except.get', []);
     }
 
     /**
@@ -119,7 +119,7 @@ class LogRequest
      */
     protected function getExceptPost() : array
     {
-        return property_exists($this, 'exceptPost') ? $this->exceptPost : config('request-logger.except.post');
+        return property_exists($this, 'exceptPost') ? $this->exceptPost : config('request-logger.except.post', []);
     }
 
     /**
@@ -127,7 +127,7 @@ class LogRequest
      */
     protected function getExceptCookies() : array
     {
-        return property_exists($this, 'exceptCookies') ? $this->exceptCookies : config('request-logger.except.cookies');
+        return property_exists($this, 'exceptCookies') ? $this->exceptCookies : config('request-logger.except.cookies'. []);
     }
 
     /**
@@ -135,7 +135,7 @@ class LogRequest
      */
     public function getExceptUri() : array
     {
-        return property_exists($this, 'exceptUri') ? $this->exceptUri : config('request-logger.except.uri');
+        return property_exists($this, 'exceptUri') ? $this->exceptUri : config('request-logger.except.uri', []);
     }
 
     /**


### PR DESCRIPTION
By default, calls to `config()` return `null` if the value hasn't been found. Because all getter functions are typehinted with `array` you get a fatal error if the config value is not defined (for example if you only want to exclude certain cookies, but no paths etc).

This PR addresses that.